### PR TITLE
Fixed issue where reference to connection.digest is not longer valid

### DIFF
--- a/src/rosbag_merge/bag_stream.py
+++ b/src/rosbag_merge/bag_stream.py
@@ -92,7 +92,7 @@ def main(input_bags: 'list[str]', topics: 'list[str]', output_path: str, outbag_
                         msgtype=connection.msgtype,
                         msgdef=connection.msgdef,
                         # connection.digest found to be used in writer.py - > write_connection(..)
-                        md5sum=connection.digest,
+                        md5sum=connection.digest if hasattr(connection, 'digest') else connection.md5sum,
                         callerid=connection.ext.callerid,
                         latching=connection.ext.latching)
                 except WriterError:


### PR DESCRIPTION
This was possibly an issue that arose with newer version of `rosbags`.